### PR TITLE
Add CLI command to launch a Jupyter notebook as a local universe job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-20.04, ubuntu-18.04, macos-10.15, windows-2019]
+        platform: [ubuntu-20.04, ubuntu-18.04]
         python-version: [3.6, 3.7, 3.8]
 
     runs-on: ${{ matrix.platform }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,4 +45,4 @@ repos:
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.782
     hooks:
-    -   id: mypy
+      - id: mypy

--- a/dask_chtc/cli.py
+++ b/dask_chtc/cli.py
@@ -507,8 +507,10 @@ class JupyterJobManager:
     def prep_log_files(self) -> None:
         JUPYTER_LOGS_DIR.mkdir(parents=True, exist_ok=True)
         for p in (self.out, self.err, self.event_log):
-            p.unlink(missing_ok=True)
-            p.touch()
+            # Path.unlink(missing_ok=True) wasn't added until Python 3.8
+            if p.exists():
+                p.unlink()
+                p.touch()
 
     def rotate_files(self) -> int:
         stamp = int(time.time())

--- a/dask_chtc/cli.py
+++ b/dask_chtc/cli.py
@@ -433,7 +433,7 @@ class JupyterJobManager:
         sub = htcondor.Submit(
             {
                 "universe": "local",
-                "JobBatchName": " ".join(["jupyter"] + jupyter_args),
+                "JobBatchName": " ".join(("jupyter", *jupyter_args)),
                 "executable": sys.executable,
                 "arguments": arguments,
                 "initialdir": Path.cwd(),

--- a/dask_chtc/cli.py
+++ b/dask_chtc/cli.py
@@ -510,7 +510,7 @@ class JupyterJobManager:
             # Path.unlink(missing_ok=True) wasn't added until Python 3.8
             if p.exists():
                 p.unlink()
-                p.touch()
+            p.touch(exist_ok=True)
 
     def rotate_files(self) -> int:
         stamp = int(time.time())

--- a/dask_chtc/cli.py
+++ b/dask_chtc/cli.py
@@ -1,3 +1,4 @@
+import io
 import logging
 import sys
 import time
@@ -128,21 +129,32 @@ def reset():
     _ensure_user_config_file()
 
 
+JUPYTER_LOGS_DIR = Path.home() / ".dask-chtc" / "jupyter-logs"
+
+
 @cli.command(context_settings=dict(ignore_unknown_options=True))
 @click.argument("jupyter_args", nargs=-1, type=click.UNPROCESSED)
 def jupyter(jupyter_args):
-    logs_dir = Path.home() / ".dask-chtc" / "jupyter-logs"
-    out = logs_dir / "current.out"
-    err = logs_dir / "current.err"
-    event_log = logs_dir / "currents.events"
+    """
+    Launch a Jupyter notebook server as an HTCondor job.
 
-    logs_dir.mkdir(parents=True, exist_ok=True)
+    All arguments after "jupyter" will be forwarded to Jupyter.
+    For example, to start Jupyter Lab on some known port, you could run
+
+        dask-chtc jupyter lab --port 3456
+    """
+    stamp = int(time.time())
+    out = JUPYTER_LOGS_DIR / f"current-{stamp}.out"
+    err = JUPYTER_LOGS_DIR / f"current-{stamp}.err"
+    event_log = JUPYTER_LOGS_DIR / f"currents-{stamp}.events"
+
+    JUPYTER_LOGS_DIR.mkdir(parents=True, exist_ok=True)
     for p in (out, err, event_log):
         p.unlink(missing_ok=True)
         p.touch()
 
     arguments = " ".join(["-m", "jupyter", *jupyter_args, "--no-browser", "-y"])
-    logger.debug(f"HTCondor job will run: {sys.executable} {arguments}")
+    logger.debug(f"HTCondor job will run this command: {sys.executable} {arguments}")
     sub = htcondor.Submit(
         {
             "universe": "local",
@@ -165,8 +177,8 @@ def jupyter(jupyter_args):
     with RunLocalUniverseJob(sub) as job:
         with out.open(mode="r") as out_file, err.open(mode="r") as err_file:
             observer = Observer()
-            observer.schedule(EchoingEventHandler(out_file, color="bright_white"), path=str(out))
-            observer.schedule(EchoingEventHandler(err_file, color="bright_white"), path=str(err))
+            observer.schedule(EchoingEventHandler(out_file), path=str(out))
+            observer.schedule(EchoingEventHandler(err_file), path=str(err))
             observer.start()
 
             jel = htcondor.JobEventLog(event_log.as_posix())
@@ -180,9 +192,9 @@ def jupyter(jupyter_args):
             observer.stop()
 
     stamp = int(time.time())
-    out.rename(logs_dir / f"previous-{stamp}.out")
-    err.rename(logs_dir / f"previous-{stamp}.err")
-    event_log.rename(logs_dir / f"previous-{stamp}.events")
+    out.rename(JUPYTER_LOGS_DIR / f"previous-{stamp}.out")
+    err.rename(JUPYTER_LOGS_DIR / f"previous-{stamp}.err")
+    event_log.rename(JUPYTER_LOGS_DIR / f"previous-{stamp}.events")
 
 
 def watch_job_events(events):
@@ -203,7 +215,7 @@ class EchoingEventHandler(events.FileSystemEventHandler):
         self.file = file
         self.color = color
 
-    def on_modified(self, event):
+    def on_modified(self, event: events.FileSystemEvent):
         for line in self.file:
             click.secho(line.rstrip(), fg=self.color, err=True)
 
@@ -213,20 +225,22 @@ class RunLocalUniverseJob:
         self.submit_description = submit_description
         self.cluster_id: Optional[int] = None
 
-    def __enter__(self):
+    def start(self) -> None:
         schedd = htcondor.Schedd()
         with schedd.transaction() as txn:
             self.cluster_id = self.submit_description.queue(txn)
         logger.debug(f"Submitted job with cluster ID {self.cluster_id}")
 
-        return self
-
-    def rm(self):
+    def rm(self) -> None:
         try:
             schedd = htcondor.Schedd()
             schedd.act(htcondor.JobAction.Remove, [f"{self.cluster_id}.0"], "Shut down Jupyter")
-        except:
+        except Exception:
             logger.exception(f"Failed to remove local universe job!")
+
+    def __enter__(self):
+        self.start()
+        return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.rm()

--- a/dask_chtc/cli.py
+++ b/dask_chtc/cli.py
@@ -433,7 +433,7 @@ class JupyterJobManager:
         sub = htcondor.Submit(
             {
                 "universe": "local",
-                "JobBatchName": " ".join(jupyter_args),
+                "JobBatchName": " ".join(["jupyter"] + jupyter_args),
                 "executable": sys.executable,
                 "arguments": arguments,
                 "initialdir": Path.cwd(),
@@ -442,6 +442,7 @@ class JupyterJobManager:
                 "log": self.event_log.as_posix(),
                 "stream_output": "true",
                 "stream_error": "true",
+                "getenv": "true",
                 "transfer_executable": "false",
                 "transfer_output_files": '""',
                 "My.IsDaskCHTCJupyterNotebookServer": "true",

--- a/dask_chtc/cli.py
+++ b/dask_chtc/cli.py
@@ -174,7 +174,6 @@ def run(jupyter_args):
 
         dask-chtc jupyter run lab --port 3456
     """
-
     with JupyterJobManager().launch(jupyter_args) as manager:
         try:
             manager.watch_events()
@@ -233,6 +232,9 @@ def stop():
 def status(raw):
     """
     Get information about your running Jupyter notebook server.
+
+    If you have launched a Jupyter notebook server in the past and need to
+    find it's address again, use this command.
     """
     now = datetime.utcnow().replace(tzinfo=timezone.utc)
 
@@ -371,7 +373,7 @@ class JupyterJobManager:
 
         self.out = self.logs_dir / f"current.out"
         self.err = self.logs_dir / f"current.err"
-        self.event_log = self.logs_dir / f"currents.events"
+        self.event_log = self.logs_dir / f"current.events"
 
         self.cluster_id: Optional[int] = None
         self.events: Optional[htcondor.JobEventLog] = None

--- a/dask_chtc/cli.py
+++ b/dask_chtc/cli.py
@@ -1,14 +1,18 @@
-import io
+import getpass
 import logging
+import re
 import sys
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 from pprint import pformat
-from typing import Optional
+from typing import List, Mapping, Optional
 
+import classad
 import click
 import dask
 import htcondor
+import humanize
 from click_didyoumean import DYMGroup
 from watchdog import events
 from watchdog.observers import Observer
@@ -56,7 +60,7 @@ def _start_logger():
 @cli.group()
 def config():
     """
-    Subcommands for inspecting and editing Dask-CHTC's configuration.
+    Inspect and edit Dask-CHTC's configuration.
 
     Dask-CHTC provides a Dask/Dask-Jobqueue configuration file which provides
     default values for the arguments of CHTCCluster.
@@ -129,90 +133,231 @@ def reset():
     _ensure_user_config_file()
 
 
-JUPYTER_LOGS_DIR = Path.home() / ".dask-chtc" / "jupyter-logs"
-
-
-@cli.command(context_settings=dict(ignore_unknown_options=True))
-@click.argument("jupyter_args", nargs=-1, type=click.UNPROCESSED)
-def jupyter(jupyter_args):
+@cli.group()
+def jupyter():
     """
-    Launch a Jupyter notebook server as an HTCondor job.
+    Run a Jupyter notebooks server as an HTCondor job.
 
-    All arguments after "jupyter" will be forwarded to Jupyter.
+    Do not run Jupyter notebook servers on CHTC submit nodes except by
+    using these commands!
+
+    Only one Jupyter notebook server can be created by this tool at a time.
+    The subcommands let you create and interact with that server
+    in various ways.
+
+    The "run" subcommand runs the notebook server as if you had started it
+    yourself. If your terminal session ends, the notebook server will also stop.
+
+    The "launch" subcommand runs the notebook server as a persistent HTCondor
+    job: it will not be removed if your terminal session ends.
+    The "status" subcommand can then be used to get information about your
+    notebook server (like its contact address, to put into your web browser).
+    The "rm" subcommand can be used to stop your launched notebook server.
+    """
+
+
+@jupyter.command(context_settings=dict(ignore_unknown_options=True))
+@click.argument("jupyter_args", nargs=-1, type=click.UNPROCESSED)
+def run(jupyter_args):
+    """
+    Run a Jupyter notebook server as an HTCondor job.
+
+    The Jupyter notebook server will be connected to your terminal session:
+    if you press Ctrl-c or disconnect from the server, your notebook server
+    will end.
+
+    To start a notebook server that is not connected to your terminal session,
+    use the "launch" subcommand.
+
+    Extra arguments will be forwarded to Jupyter.
     For example, to start Jupyter Lab on some known port, you could run
 
-        dask-chtc jupyter lab --port 3456
+        dask-chtc jupyter run lab --port 3456
     """
-    stamp = int(time.time())
-    out = JUPYTER_LOGS_DIR / f"current-{stamp}.out"
-    err = JUPYTER_LOGS_DIR / f"current-{stamp}.err"
-    event_log = JUPYTER_LOGS_DIR / f"currents-{stamp}.events"
 
-    JUPYTER_LOGS_DIR.mkdir(parents=True, exist_ok=True)
-    for p in (out, err, event_log):
-        p.unlink(missing_ok=True)
-        p.touch()
+    with JupyterJobManager().launch(jupyter_args) as manager:
+        try:
+            manager.watch_events()
+        except KeyboardInterrupt:
+            pass
 
-    arguments = " ".join(["-m", "jupyter", *jupyter_args, "--no-browser", "-y"])
-    logger.debug(f"HTCondor job will run this command: {sys.executable} {arguments}")
-    sub = htcondor.Submit(
-        {
-            "universe": "local",
-            "JobBatchName": "dask-chtc jupyter",
-            "executable": sys.executable,
-            "arguments": arguments,
-            "initialdir": Path.cwd(),
-            "getenv": "true",
-            "output": out.as_posix(),
-            "error": err.as_posix(),
-            "log": event_log.as_posix(),
-            "stream_output": "true",
-            "stream_error": "true",
-            "transfer_executable": "false",
-            "transfer_output_files": '""',
-            "My.IsDaskCHTCJupyterNotebook": "true",
-        }
+
+@jupyter.command(context_settings=dict(ignore_unknown_options=True))
+@click.argument("jupyter_args", nargs=-1, type=click.UNPROCESSED)
+def launch(jupyter_args):
+    """
+    Launch a Jupyter notebook server as a persistent HTCondor job.
+
+    Just like the "run" subcommand, this will start a Jupyter notebook server
+    and show you any output from it.
+    Unlike the "run" subcommand,
+    the Jupyter notebook server will not be connected to your terminal session:
+    if you press Ctrl-c or disconnect from the server, your notebook server
+    will continue running (though you will stop seeing output from it).
+
+    You can see the status of a persistent notebook server started by this
+    command by using the "status" subcommand.
+
+    To start a notebook server that is connected to your terminal session,
+    use the "run" subcommand.
+
+    Extra arguments will be forwarded to Jupyter.
+    For example, to start Jupyter Lab on some known port, you could run
+
+        dask-chtc jupyter run lab --port 3456
+    """
+
+    manager = JupyterJobManager().launch(jupyter_args)
+    manager.start_echoing()
+    try:
+        manager.watch_events()
+    except KeyboardInterrupt:
+        pass
+
+
+@jupyter.command()
+def stop():
+    """
+    Stop your running Jupyter notebook server.
+    """
+    JupyterJobManager().connect().stop()
+
+
+@jupyter.command()
+@click.option(
+    "--raw",
+    is_flag=True,
+    default=False,
+    help="Print the raw HTCondor job ad instead of the formatted output.",
+)
+def status(raw):
+    """
+    Get information about your running Jupyter notebook server.
+    """
+    now = datetime.utcnow().replace(tzinfo=timezone.utc)
+
+    manager = JupyterJobManager()
+    job = manager.discover()
+
+    if raw:
+        click.echo(job)
+        return
+
+    status_msg = click.style(f"█ {job.status}".ljust(10), fg=JOB_STATUS_TO_COLOR.get(job.status))
+
+    lines = [f"{status_msg} {job.get('JobBatchName', 'ID: ' + str(job.cluster_id))}"]
+    lines.extend(
+        [
+            f"Hold Reason: {job.hold_reason}" if job.is_held else None,
+            f"Contact Address: {manager.contact_address}",
+            f"Python Executable: {job.executable}",
+            f"Launch Directory:  {job.iwd}",
+            f"Job ID: {job.cluster_id}.{job.proc_id}",
+            f"Last status change at:  {job.status_last_changed_at} UTC ({humanize.naturaldelta(now - job.status_last_changed_at)} ago)",
+            f"Originally launched at: {job.submitted_at} UTC ({humanize.naturaldelta(now - job.submitted_at)} ago)",
+            f"Output: {job.stdout}",
+            f"Error:  {job.stderr}",
+            f"Events: {job.log}",
+        ]
     )
 
-    with RunLocalUniverseJob(sub) as job:
-        with out.open(mode="r") as out_file, err.open(mode="r") as err_file:
-            observer = Observer()
-            observer.schedule(EchoingEventHandler(out_file), path=str(out))
-            observer.schedule(EchoingEventHandler(err_file), path=str(err))
-            observer.start()
-
-            jel = htcondor.JobEventLog(event_log.as_posix())
-            events = jel.events(None)
-            try:
-                watch_job_events(events)
-            except KeyboardInterrupt:
-                job.rm()
-                watch_job_events(events)
-
-            observer.stop()
-
-    stamp = int(time.time())
-    out.rename(JUPYTER_LOGS_DIR / f"previous-{stamp}.out")
-    err.rename(JUPYTER_LOGS_DIR / f"previous-{stamp}.err")
-    event_log.rename(JUPYTER_LOGS_DIR / f"previous-{stamp}.events")
+    # format the output
+    lines = list(filter(None, lines))
+    rows = [lines[0]]
+    for line in lines[1:-1]:
+        rows.append("├─ " + line)
+    rows.append("└─ " + lines[-1])
+    rows.append("")
+    click.echo("\n".join(rows))
 
 
-def watch_job_events(events):
-    for event in events:
-        text = str(event).rstrip()
-        if event.type in (htcondor.JobEventType.JOB_HELD, htcondor.JobEventType.JOB_TERMINATED):
-            click.secho(text, err=True, fg="red")
-            break
-        elif event.type is htcondor.JobEventType.JOB_ABORTED:
-            click.secho(text, err=True, fg="white")
-            break
-        else:
-            click.secho(text, err=True, fg="white")
+JOB_STATUS_MAPPING = {1: "IDLE", 2: "RUNNING", 3: "REMOVED", 4: "COMPLETED", 5: "HELD"}
+JOB_STATUS_TO_COLOR = {"IDLE": "yellow", "RUNNING": "green", "HELD": "red", "REMOVED": "magenta"}
+
+
+class Job(Mapping):
+    def __init__(self, ad: classad.ClassAd):
+        self._ad = ad
+
+    def __iter__(self):
+        yield from self.keys()
+
+    def __len__(self) -> int:
+        return len(self._ad)
+
+    def __getitem__(self, item):
+        return self._ad[item]
+
+    def items(self):
+        yield from self._ad.items()
+
+    def keys(self):
+        yield from self._ad.keys()
+
+    def values(self):
+        yield from self._ad.values()
+
+    def __str__(self):
+        return str(self._ad)
+
+    @property
+    def cluster_id(self) -> int:
+        return self._ad["ClusterId"]
+
+    @property
+    def proc_id(self) -> int:
+        return self._ad["ProcId"]
+
+    @property
+    def executable(self) -> str:
+        return self._ad["Cmd"]
+
+    @property
+    def iwd(self) -> Path:
+        return Path(self._ad["Iwd"]).absolute()
+
+    @property
+    def submitted_at(self) -> datetime:
+        return datetime.fromtimestamp(self._ad["QDate"]).astimezone(timezone.utc)
+
+    @property
+    def status_last_changed_at(self) -> datetime:
+        return datetime.fromtimestamp(self._ad["EnteredCurrentStatus"]).astimezone(timezone.utc)
+
+    @property
+    def status(self) -> str:
+        return JOB_STATUS_MAPPING[self._ad["JobStatus"]]
+
+    @property
+    def is_held(self) -> bool:
+        return self.status == "HELD"
+
+    @property
+    def hold_reason(self) -> str:
+        return self._ad["HoldReason"]
+
+    @property
+    def stdout(self) -> Path:
+        p = Path(self._ad["Out"])
+        if not p.is_absolute():
+            return (self.iwd / self._ad["Out"]).absolute()
+        return p
+
+    @property
+    def stderr(self) -> Path:
+        p = Path(self._ad["Err"])
+        if not p.is_absolute():
+            return (self.iwd / self._ad["Err"]).absolute()
+        return p
+
+    @property
+    def log(self) -> Path:
+        return Path(self._ad["UserLog"]).absolute()
 
 
 class EchoingEventHandler(events.FileSystemEventHandler):
-    def __init__(self, file, color: Optional[str] = None):
-        self.file = file
+    def __init__(self, path: Path, color: Optional[str] = None):
+        self.file = path.open(mode="r")
         self.color = color
 
     def on_modified(self, event: events.FileSystemEvent):
@@ -220,27 +365,170 @@ class EchoingEventHandler(events.FileSystemEventHandler):
             click.secho(line.rstrip(), fg=self.color, err=True)
 
 
-class RunLocalUniverseJob:
-    def __init__(self, submit_description: htcondor.Submit):
-        self.submit_description = submit_description
+JUPYTER_LOGS_DIR = Path.home() / ".dask-chtc" / "jupyter-logs"
+
+
+class JupyterJobManager:
+    def __init__(self):
         self.cluster_id: Optional[int] = None
 
-    def start(self) -> None:
+        self.out = JUPYTER_LOGS_DIR / f"current.out"
+        self.err = JUPYTER_LOGS_DIR / f"current.err"
+        self.event_log = JUPYTER_LOGS_DIR / f"currents.events"
+
+        self.events: Optional[htcondor.JobEventLog] = None
+        self.observer: Optional[Observer] = None
+
+    @classmethod
+    def discover(cls) -> Job:
+        schedd = htcondor.Schedd()
+
+        query = schedd.query(constraint=f"Owner == {classad.quote(getpass.getuser())}",)
+        if len(query) == 0:
+            raise click.ClickException(
+                "Was not able to find a running Jupyter notebook server job!"
+            )
+
+        return Job(query[0])
+
+    @classmethod
+    def has_running_job(cls) -> bool:
+        try:
+            cls.discover()
+            return True
+        except click.ClickException:
+            return False
+
+    def connect(self) -> "JupyterJobManager":
+        job_ad = self.discover()
+
+        self.cluster_id = job_ad["ClusterId"]
+
+        return self
+
+    @property
+    def contact_address(self) -> str:
+        jupyter_logs = self.err.read_text().splitlines()
+        contact_addresses = set()
+        for line in jupyter_logs:
+            match = re.search(r"https?://.+/?token=.+$", line)
+            if match:
+                contact_addresses.add(match.group(0))
+
+        if len(contact_addresses) == 0:
+            raise Exception("Could not find contact address for Jupyter notebook server from logs")
+
+        # TODO: this choice is extremely arbitrary...
+        return sorted(contact_addresses)[0]
+
+    def launch(self, jupyter_args: List[str]) -> "JupyterJobManager":
+        if self.has_running_job():
+            raise click.ClickException(
+                'You already have a running Jupyter notebook server; try the "status" subcommand to see it.'
+            )
+
+        self.prep_log_files()
+
+        arguments = " ".join(["-m", "jupyter", *jupyter_args, "--no-browser", "-y"])
+        sub = htcondor.Submit(
+            {
+                "universe": "local",
+                "JobBatchName": " ".join(jupyter_args),
+                "executable": sys.executable,
+                "arguments": arguments,
+                "initialdir": Path.cwd(),
+                "output": self.out.as_posix(),
+                "error": self.err.as_posix(),
+                "log": self.event_log.as_posix(),
+                "stream_output": "true",
+                "stream_error": "true",
+                "transfer_executable": "false",
+                "transfer_output_files": '""',
+                "My.IsDaskCHTCJupyterNotebookServer": "true",
+            }
+        )
+
+        logger.debug(f"HTCondor job submit description:\n{sub}")
+
         schedd = htcondor.Schedd()
         with schedd.transaction() as txn:
-            self.cluster_id = self.submit_description.queue(txn)
+            self.cluster_id = sub.queue(txn)
+
         logger.debug(f"Submitted job with cluster ID {self.cluster_id}")
 
-    def rm(self) -> None:
+        return self
+
+    def watch_events(self) -> None:
+        if self.events is None:
+            self.events = htcondor.JobEventLog(self.event_log.as_posix())
+
+        for event in self.events:
+            text = str(event).rstrip()
+            if event.type in (htcondor.JobEventType.JOB_HELD, htcondor.JobEventType.JOB_TERMINATED):
+                click.secho(text, err=True, fg="red")
+                break
+            elif event.type is htcondor.JobEventType.JOB_ABORTED:
+                click.secho(text, err=True, fg="white")
+                break
+            else:
+                click.secho(text, err=True, fg="white")
+
+    def remove_job(self) -> None:
         try:
             schedd = htcondor.Schedd()
-            schedd.act(htcondor.JobAction.Remove, [f"{self.cluster_id}.0"], "Shut down Jupyter")
+            schedd.act(
+                htcondor.JobAction.Remove,
+                [f"{self.cluster_id}.0"],
+                "Shut down Jupyter notebook server",
+            )
         except Exception:
-            logger.exception(f"Failed to remove local universe job!")
+            logger.exception(f"Failed to remove Jupyter notebook server job!")
 
-    def __enter__(self):
-        self.start()
+    def start_echoing(self) -> None:
+        if self.observer is not None:
+            return
+
+        self.observer = Observer()
+        self.observer.schedule(EchoingEventHandler(self.out), path=str(self.out))
+        self.observer.schedule(EchoingEventHandler(self.err), path=str(self.err))
+        self.observer.start()
+
+        logger.debug("Started echoing job log files")
+
+    def stop_echoing(self) -> None:
+        if self.observer is None:
+            return
+
+        self.observer.stop()
+        self.observer = None
+
+        logger.debug("Stopped echoing job log files")
+
+    def prep_log_files(self) -> None:
+        JUPYTER_LOGS_DIR.mkdir(parents=True, exist_ok=True)
+        for p in (self.out, self.err, self.event_log):
+            p.unlink(missing_ok=True)
+            p.touch()
+
+    def rotate_files(self) -> int:
+        stamp = int(time.time())
+
+        self.out.rename(JUPYTER_LOGS_DIR / f"previous-{stamp}.out")
+        self.err.rename(JUPYTER_LOGS_DIR / f"previous-{stamp}.err")
+        self.event_log.rename(JUPYTER_LOGS_DIR / f"previous-{stamp}.events")
+
+        return stamp
+
+    def stop(self) -> None:
+        self.start_echoing()
+        self.remove_job()
+        self.watch_events()
+        self.stop_echoing()
+        self.rotate_files()
+
+    def __enter__(self) -> "JupyterJobManager":
+        self.start_echoing()
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        self.rm()
+        self.stop()

--- a/dask_chtc/cluster.py
+++ b/dask_chtc/cluster.py
@@ -47,7 +47,7 @@ class CHTCCluster(HTCondorCluster):
         worker_image
             The Docker image to run the Dask workers inside.
             Defaults to ``daskdev/dask:latest``
-            (https://hub.docker.com/r/daskdev/dask).
+            (https://hub.docker.com/r/daskdev/dask/dockerfile).
         gpu_lab
             If ``True``, workers will be allowed to run on GPULab nodes.
             If this is ``True``, the default value of ``gpus`` becomes ``1``.

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-files = dask_chtc/**/*.py
+files = dask_chtc/*.py
 
 ignore_missing_imports = True
 no_implicit_optional = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,7 @@
 [mypy]
-mypy_path = dask_chtc
+files = dask_chtc/**/*.py
 
 ignore_missing_imports = True
+no_implicit_optional = True
 
 pretty = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ target-version = ["py36", "py37", "py38"]
 include = "\\.pyi?$"
 
 [tool.isort]
-known_third_party = ["click", "click_didyoumean", "dask", "dask_jobqueue", "htcondor", "numpy", "pandas", "pytest", "setuptools", "sklearn", "watchdog", "yaml"]
+known_third_party = ["classad", "click", "click_didyoumean", "dask", "dask_jobqueue", "htcondor", "humanize", "numpy", "pandas", "pytest", "setuptools", "sklearn", "watchdog", "yaml"]
 line_length = 100
 multi_line_output = "VERTICAL_HANGING_INDENT"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ target-version = ["py36", "py37", "py38"]
 include = "\\.pyi?$"
 
 [tool.isort]
-known_third_party = ["click", "click_didyoumean", "dask", "dask_jobqueue", "numpy", "pandas", "pytest", "setuptools", "sklearn", "yaml"]
+known_third_party = ["click", "click_didyoumean", "dask", "dask_jobqueue", "htcondor", "numpy", "pandas", "pytest", "setuptools", "sklearn", "watchdog", "yaml"]
 line_length = 100
 multi_line_output = "VERTICAL_HANGING_INDENT"
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,8 @@ install_requires =
     click-didyoumean
     dask
     dask-jobqueue@git+https://github.com/dask/dask-jobqueue.git@0049ba7df81e3b687f0243f82b106df7a1e2ed32
-    htcondor
+    htcondor>=8.9.8a2
+    humanize
     pyyaml
     watchdog
     importlib-metadata>=1.0;python_version < "3.8"

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,9 @@ install_requires =
     click-didyoumean
     dask
     dask-jobqueue@git+https://github.com/dask/dask-jobqueue.git@0049ba7df81e3b687f0243f82b106df7a1e2ed32
+    htcondor
     pyyaml
+    watchdog
     importlib-metadata>=1.0;python_version < "3.8"
 python_requires = >=3.6
 include_package_data = True


### PR DESCRIPTION
This PR will resolve #9 . When you run it, it looks like this:

```
$ dask-chtc -v jupyter lab --port 3400
2020-07-09 16:38:52,695 ~ DEBUG ~ dask_chtc.cli:37 ~ CLI called with arguments "-v jupyter lab --port 3400"
2020-07-09 16:38:52,695 ~ DEBUG ~ dask_chtc.cli:145 ~ HTCondor job will run: /home/jkarpel/.python/envs/htcondor-dask/bin/python -m jupyter lab --port 3400 --no-browser -y
2020-07-09 16:38:52,707 ~ DEBUG ~ dask_chtc.cli:220 ~ Submitted job with cluster ID 16407
000 (16407.000.000) 2020-07-09 16:38:52 Job submitted from host: <10.0.1.43:40959?addrs=10.0.1.43-40959+[2600-6c44-1180-1661-f999-f483-eaa-ea88]-40959&alias=JKARPEL&noUDP&sock=schedd_29498_1128>
001 (16407.000.000) 2020-07-09 16:38:54 Job executing on host: <10.0.1.43:40959?addrs=10.0.1.43-40959+[2600-6c44-1180-1661-f999-f483-eaa-ea88]-40959&alias=JKARPEL&noUDP&sock=starter_29523_5fca_34>
[I 16:38:55.778 LabApp] The port 3400 is already in use, trying another port.
[I 16:38:56.458 LabApp] JupyterLab extension loaded from /home/jkarpel/.python/envs/htcondor-dask/lib/python3.8/site-packages/jupyterlab
[I 16:38:56.459 LabApp] JupyterLab application directory is /home/jkarpel/.python/envs/htcondor-dask/share/jupyter/lab
[I 16:38:56.460 LabApp] Serving notebooks from local directory: /home/jkarpel
[I 16:38:56.460 LabApp] The Jupyter Notebook is running at:
[I 16:38:56.460 LabApp] http://localhost:3401/?token=6d6ab69b958b886d8a2b0dfb352b33da0455fbbc65934b5d
[I 16:38:56.460 LabApp]  or http://127.0.0.1:3401/?token=6d6ab69b958b886d8a2b0dfb352b33da0455fbbc65934b5d
[I 16:38:56.460 LabApp] Use Control-C to stop this server and shut down all kernels (twice to skip confirmation).
[C 16:38:56.462 LabApp]

    To access the notebook, open this file in a browser:
        file:///home/jkarpel/.local/share/jupyter/runtime/nbserver-13718-open.html
    Or copy and paste one of these URLs:
        http://localhost:3401/?token=6d6ab69b958b886d8a2b0dfb352b33da0455fbbc65934b5d
     or http://127.0.0.1:3401/?token=6d6ab69b958b886d8a2b0dfb352b33da0455fbbc65934b5d
^C[C 16:38:58.472 LabApp] received signal 15, stopping
[I 16:38:58.473 LabApp] Shutting down 0 kernels
004 (16407.000.000) 2020-07-09 16:38:58 Job was evicted.
	(0) CPU times
		Usr 0 00:00:00, Sys 0 00:00:00  -  Run Remote Usage
		Usr 0 00:00:00, Sys 0 00:00:00  -  Run Local Usage
	0  -  Run Bytes Sent By Job
	0  -  Run Bytes Received By Job
009 (16407.000.000) 2020-07-09 16:38:58 Job was aborted.
	Shut down Jupyter (by user jkarpel)
```