### PR TITLE
Use TLS for all communications

### DIFF
--- a/dask_chtc/__init__.py
+++ b/dask_chtc/__init__.py
@@ -1,8 +1,13 @@
+import logging as _logging
+
+# Set up null log handler
+_logger = _logging.getLogger(__name__)
+_logger.setLevel(_logging.DEBUG)
+_logger.addHandler(_logging.NullHandler())
+
 from .cluster import CHTCCluster
 from .config import _ensure_user_config_file, _set_base_config
-from .security import _ensure_certs
 from .version import __version__
 
 _ensure_user_config_file()
 _set_base_config()
-_ensure_certs()

--- a/dask_chtc/__init__.py
+++ b/dask_chtc/__init__.py
@@ -1,6 +1,8 @@
 from .cluster import CHTCCluster
 from .config import _ensure_user_config_file, _set_base_config
+from .security import _ensure_certs
 from .version import __version__
 
 _ensure_user_config_file()
 _set_base_config()
+_ensure_certs()

--- a/dask_chtc/cluster.py
+++ b/dask_chtc/cluster.py
@@ -87,9 +87,6 @@ class CHTCCluster(HTCondorCluster):
         python
             The command to execute to start Python inside the worker job.
             Only modify this if you know what you're doing!
-        protocol
-            The security protocol to use.
-            Do not change this!
         kwargs
             Additional keyword arguments,
             like ``cores`` or ``memory``,
@@ -123,15 +120,17 @@ class CHTCCluster(HTCondorCluster):
         # Security settings.
         # Worker security configuration is done in entrypoint.sh;
         # this mainly effects the client and scheduler.
-        kwargs["protocol"] = "tls://"
-        kwargs["security"] = Security(
-            tls_ca_file=CA_FILE,
-            tls_worker_cert=CERT_FILE,
-            tls_worker_key=CERT_FILE,
-            tls_client_cert=CERT_FILE,
-            tls_client_key=CERT_FILE,
-            tls_scheduler_cert=CERT_FILE,
-            tls_scheduler_key=CERT_FILE,
+        modified["protocol"] = "tls://"
+        ca_file = str(CA_FILE)
+        cert_file = str(CERT_FILE)
+        modified["security"] = Security(
+            tls_ca_file=ca_file,
+            tls_worker_cert=cert_file,
+            tls_worker_key=cert_file,
+            tls_client_cert=cert_file,
+            tls_client_key=cert_file,
+            tls_scheduler_cert=cert_file,
+            tls_scheduler_key=cert_file,
             require_encryption=True,
         )
 

--- a/dask_chtc/cluster.py
+++ b/dask_chtc/cluster.py
@@ -31,7 +31,7 @@ class CHTCJob(HTCondorJob):
     def __init__(self, *args, **kwargs):
         # Suppress automatic addition of TLS config options to the worker args
         # (so that we can add our own in entrypoint.sh).
-        kwargs["security"].pop()
+        kwargs.pop("security")
 
         super().__init__(*args, **kwargs)
 

--- a/dask_chtc/cluster.py
+++ b/dask_chtc/cluster.py
@@ -12,7 +12,7 @@ from dask_jobqueue import HTCondorCluster
 from dask_jobqueue.htcondor import HTCondorJob
 from distributed.security import Security
 
-from .security import CA_FILE, CERT_FILE
+from .security import CA_FILE, CERT_FILE, ensure_certs
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
@@ -92,6 +92,7 @@ class CHTCCluster(HTCondorCluster):
             like ``cores`` or ``memory``,
             are passed to :class:`dask_jobqueue.HTCondorCluster`.
         """
+
         kwargs = self._modify_kwargs(
             kwargs, worker_image=worker_image, gpu_lab=gpu_lab, gpus=gpus, batch_name=batch_name,
         )
@@ -120,6 +121,7 @@ class CHTCCluster(HTCondorCluster):
         # Security settings.
         # Worker security configuration is done in entrypoint.sh;
         # this mainly effects the client and scheduler.
+        ensure_certs()
         modified["protocol"] = "tls://"
         ca_file = str(CA_FILE)
         cert_file = str(CERT_FILE)

--- a/dask_chtc/entrypoint.sh
+++ b/dask_chtc/entrypoint.sh
@@ -33,5 +33,13 @@ echo "HOST is $HOST"
 echo "PORT is $PORT"
 echo
 
-# Add the contact address we calculated above the worker arguments.
-exec "$@" --contact-address tcp://"$HOST":"$PORT"
+# Paths to TLS config files, transferred to the worker by HTCondor file transfer.
+FILE_CA="$_CONDOR_SCRATCH_DIR/ca.pem"
+FILE_CERT="$_CONDOR_SCRATCH_DIR/cert.pem"
+FILE_KEY="$_CONDOR_SCRATCH_DIR/cert.pem"
+
+# Add the contact address we calculated above to the worker arguments,
+# as well as TLS configuration.
+exec "$@" \
+  --contact-address tls://"$HOST":"$PORT" \
+  --tls-ca-file "$FILE_CA" --tls-cert "$FILE_CERT" --tls-key "$FILE_KEY"

--- a/dask_chtc/security.py
+++ b/dask_chtc/security.py
@@ -27,7 +27,8 @@ BASE_NAME_ATTRIBUTES = [
 ]
 
 
-def generate_private_key() -> rsa.RSAPrivateKeyWithSerialization:
+def generate_key() -> rsa.RSAPrivateKeyWithSerialization:
+    """Generate an RSA private key."""
     return rsa.generate_private_key(public_exponent=65537, key_size=2048, backend=BACKEND)
 
 
@@ -46,7 +47,7 @@ def generate_ca() -> CertAndKey:
     """
     now = datetime.utcnow()
 
-    key = generate_private_key()
+    key = generate_key()
 
     subject = issuer = x509.Name(
         [*BASE_NAME_ATTRIBUTES, x509.NameAttribute(x509.NameOID.COMMON_NAME, "Dask-CHTC CA")]
@@ -83,7 +84,7 @@ def generate_cert(ca_and_key: CertAndKey) -> CertAndKey:
     """
     now = datetime.utcnow()
 
-    key = generate_private_key()
+    key = generate_key()
 
     name = x509.Name(
         [*BASE_NAME_ATTRIBUTES, x509.NameAttribute(x509.NameOID.COMMON_NAME, "Dask-CHTC")]
@@ -158,7 +159,12 @@ def save_cert(path: Path, cert_and_key=CertAndKey) -> Path:
 
 def delete_certs():
     """Remove **all** certificates managed by Dask-CHTC."""
-    shutil.rmtree(CERT_DIR, ignore_errors=True)
+    if not CERT_DIR.exists():
+        return
+
+    logger.debug("Deleting all existing Dask-CHTC certificates...")
+    shutil.rmtree(CERT_DIR)
+    logger.debug("Deleted all existing Dask-CHTC certificates.")
 
 
 def ensure_certs():

--- a/dask_chtc/security.py
+++ b/dask_chtc/security.py
@@ -1,0 +1,136 @@
+import shutil
+import stat
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from cryptography import x509
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+CERT_DIR = Path.home() / ".dask-chtc" / "certs"
+CA_FILE = CERT_DIR / "ca.pem"
+CERT_FILE = CERT_DIR / "cert.pem"
+
+BACKEND = default_backend()
+
+BASE_NAME_ATTRIBUTES = [
+    x509.NameAttribute(x509.NameOID.COUNTRY_NAME, "US"),
+    x509.NameAttribute(x509.NameOID.STATE_OR_PROVINCE_NAME, "WI"),
+    x509.NameAttribute(x509.NameOID.LOCALITY_NAME, "Madison"),
+    x509.NameAttribute(x509.NameOID.ORGANIZATION_NAME, "CHTC"),
+]
+
+
+def generate_private_key() -> rsa.RSAPrivateKeyWithSerialization:
+    return rsa.generate_private_key(public_exponent=65537, key_size=2048, backend=BACKEND)
+
+
+def generate_ca_and_key():
+    now = datetime.utcnow()
+
+    key = generate_private_key()
+
+    subject = issuer = x509.Name(
+        [*BASE_NAME_ATTRIBUTES, x509.NameAttribute(x509.NameOID.COMMON_NAME, "Dask-CHTC CA")]
+    )
+    ca = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - timedelta(days=1))
+        .not_valid_after(now + timedelta(days=365))
+        .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+        .sign(private_key=key, algorithm=hashes.SHA256(), backend=BACKEND)
+    )
+
+    return ca, key
+
+
+def generate_server_cert_and_key(ca_cert, ca_key):
+    """
+    Generate a certificate for the
+
+    Parameters
+    ----------
+    ca_cert
+    ca_key
+    common_name
+
+    Returns
+    -------
+
+    """
+    now = datetime.utcnow()
+
+    key = generate_private_key()
+
+    name = x509.Name(
+        [*BASE_NAME_ATTRIBUTES, x509.NameAttribute(x509.NameOID.COMMON_NAME, "Dask-CHTC")]
+    )
+
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(ca_cert.subject)
+        .not_valid_before(now - timedelta(days=1))
+        .not_valid_after(now + timedelta(days=365))
+        .serial_number(x509.random_serial_number())
+        .public_key(key.public_key())
+        .add_extension(
+            x509.KeyUsage(
+                digital_signature=True,
+                content_commitment=False,
+                key_encipherment=True,
+                data_encipherment=False,
+                key_agreement=False,
+                key_cert_sign=False,
+                crl_sign=False,
+                encipher_only=False,
+                decipher_only=False,
+            ),
+            critical=True,
+        )
+        .add_extension(
+            x509.ExtendedKeyUsage(
+                [x509.ExtendedKeyUsageOID.CLIENT_AUTH, x509.ExtendedKeyUsageOID.SERVER_AUTH]
+            ),
+            critical=True,
+        )
+        .sign(private_key=ca_key, algorithm=hashes.SHA256(), backend=default_backend())
+    )
+
+    return cert, key
+
+
+def save_cert_and_key(path: Path, cert: x509.Certificate, key: rsa.RSAPrivateKeyWithSerialization):
+    path.parent.mkdir(exist_ok=True, parents=True)
+    path.touch(mode=stat.S_IRUSR | stat.S_IWUSR, exist_ok=False)
+    with path.open(mode="wb") as f:
+        f.write(cert.public_bytes(encoding=serialization.Encoding.PEM))
+        f.write(
+            key.private_bytes(
+                encoding=serialization.Encoding.PEM,
+                format=serialization.PrivateFormat.TraditionalOpenSSL,
+                encryption_algorithm=serialization.NoEncryption(),
+            )
+        )
+
+    return path
+
+
+def _ensure_certs():
+    # TODO: also check that the certs aren't expired/about to expire
+    if CA_FILE.exists() and CERT_FILE.exists():
+        return
+
+    # Blow away any old certs lying around
+    shutil.rmtree(CERT_DIR, ignore_errors=True)
+
+    ca_cert, ca_key = generate_ca_and_key()
+    cert, key = generate_server_cert_and_key(ca_cert, ca_key)
+
+    save_cert_and_key(CA_FILE, ca_cert, ca_key)
+    save_cert_and_key(CERT_FILE, cert, key)

--- a/dask_chtc/security.py
+++ b/dask_chtc/security.py
@@ -1,3 +1,5 @@
+import collections
+import logging
 import shutil
 import stat
 from datetime import datetime, timedelta
@@ -7,6 +9,9 @@ from cryptography import x509
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
 
 CERT_DIR = Path.home() / ".dask-chtc" / "certs"
 CA_FILE = CERT_DIR / "ca.pem"
@@ -26,7 +31,19 @@ def generate_private_key() -> rsa.RSAPrivateKeyWithSerialization:
     return rsa.generate_private_key(public_exponent=65537, key_size=2048, backend=BACKEND)
 
 
-def generate_ca_and_key():
+CertAndKey = collections.namedtuple("CertAndKey", ("cert", "key"))
+
+
+def generate_ca() -> CertAndKey:
+    """
+    Generate a new self-signed CA certificate.
+
+    Returns
+    -------
+    ca_and_key : CertAndKey
+        A :class:`CertAndKey` holding the newly-generated CA certificate and its
+        private key.
+    """
     now = datetime.utcnow()
 
     key = generate_private_key()
@@ -46,22 +63,23 @@ def generate_ca_and_key():
         .sign(private_key=key, algorithm=hashes.SHA256(), backend=BACKEND)
     )
 
-    return ca, key
+    return CertAndKey(ca, key)
 
 
-def generate_server_cert_and_key(ca_cert, ca_key):
+def generate_cert(ca_and_key: CertAndKey) -> CertAndKey:
     """
-    Generate a certificate for the
+    Generate a certificate signed by the given CA.
 
     Parameters
     ----------
-    ca_cert
-    ca_key
-    common_name
+    ca_and_key
+        A :class:`CertAndKey` holding the CA certificate and corresponding key.
 
     Returns
     -------
-
+    cert_and_key : CertAndKey
+        A :class:`CertAndKey` holding the newly-generated certificate and its
+        private key.
     """
     now = datetime.utcnow()
 
@@ -74,7 +92,7 @@ def generate_server_cert_and_key(ca_cert, ca_key):
     cert = (
         x509.CertificateBuilder()
         .subject_name(name)
-        .issuer_name(ca_cert.subject)
+        .issuer_name(ca_and_key.cert.subject)
         .not_valid_before(now - timedelta(days=1))
         .not_valid_after(now + timedelta(days=365))
         .serial_number(x509.random_serial_number())
@@ -99,19 +117,36 @@ def generate_server_cert_and_key(ca_cert, ca_key):
             ),
             critical=True,
         )
-        .sign(private_key=ca_key, algorithm=hashes.SHA256(), backend=default_backend())
+        .sign(private_key=ca_and_key.key, algorithm=hashes.SHA256(), backend=default_backend())
     )
 
-    return cert, key
+    return CertAndKey(cert, key)
 
 
-def save_cert_and_key(path: Path, cert: x509.Certificate, key: rsa.RSAPrivateKeyWithSerialization):
+def save_cert(path: Path, cert_and_key=CertAndKey) -> Path:
+    """
+    Save a :class:`CertAndKey` to a single file.
+    The key and cert will be concatenated together.
+
+    Parameters
+    ----------
+    path
+        The path to save the file to.
+    cert_and_key
+        A :class:`CertAndKey` to save.
+
+    Returns
+    -------
+    path : Path
+        The path that they key and cert were saved to.
+    """
+    path = Path(path).absolute()
     path.parent.mkdir(exist_ok=True, parents=True)
     path.touch(mode=stat.S_IRUSR | stat.S_IWUSR, exist_ok=False)
     with path.open(mode="wb") as f:
-        f.write(cert.public_bytes(encoding=serialization.Encoding.PEM))
+        f.write(cert_and_key.cert.public_bytes(encoding=serialization.Encoding.PEM))
         f.write(
-            key.private_bytes(
+            cert_and_key.key.private_bytes(
                 encoding=serialization.Encoding.PEM,
                 format=serialization.PrivateFormat.TraditionalOpenSSL,
                 encryption_algorithm=serialization.NoEncryption(),
@@ -121,16 +156,36 @@ def save_cert_and_key(path: Path, cert: x509.Certificate, key: rsa.RSAPrivateKey
     return path
 
 
-def _ensure_certs():
-    # TODO: also check that the certs aren't expired/about to expire
-    if CA_FILE.exists() and CERT_FILE.exists():
-        return
-
-    # Blow away any old certs lying around
+def delete_certs():
+    """Remove **all** certificates managed by Dask-CHTC."""
     shutil.rmtree(CERT_DIR, ignore_errors=True)
 
-    ca_cert, ca_key = generate_ca_and_key()
-    cert, key = generate_server_cert_and_key(ca_cert, ca_key)
 
-    save_cert_and_key(CA_FILE, ca_cert, ca_key)
-    save_cert_and_key(CERT_FILE, cert, key)
+def ensure_certs():
+    """
+    Ensure that valid certificates that will continue to be valid for a while
+    exist. If they don't exist, this function will create them. If they do exist,
+    this function won't replace them.
+    """
+    if CA_FILE.exists() and CERT_FILE.exists():
+        old_cert = x509.load_pem_x509_certificate(data=CA_FILE.read_bytes(), backend=BACKEND,)
+
+        # check that the certs will not expire in the next two weeks
+        if old_cert.not_valid_after > (datetime.utcnow() + timedelta(days=14)):
+            logger.debug(
+                "Skipping TLS certificate creation because we have existing long-lived certificates."
+            )
+            return
+
+    logger.debug("Creating new TLS certificates...")
+
+    # Blow away any old certs lying around
+    delete_certs()
+
+    ca = generate_ca()
+    cert = generate_cert(ca)
+
+    save_cert(CA_FILE, ca)
+    save_cert(CERT_FILE, cert)
+
+    logger.debug("Created new TLS certificates.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ target-version = ["py36", "py37", "py38"]
 include = "\\.pyi?$"
 
 [tool.isort]
-known_third_party = ["classad", "click", "click_didyoumean", "dask", "dask_jobqueue", "htcondor", "humanize", "numpy", "pandas", "psutil", "pytest", "setuptools", "sklearn", "sphinx_rtd_theme", "watchdog", "yaml"]
+known_third_party = ["classad", "click", "click_didyoumean", "cryptography", "dask", "dask_jobqueue", "distributed", "htcondor", "humanize", "numpy", "pandas", "psutil", "pytest", "setuptools", "sklearn", "sphinx_rtd_theme", "watchdog", "yaml"]
 line_length = 100
 multi_line_output = "VERTICAL_HANGING_INDENT"
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ packages =
 install_requires =
     click>=7.0
     click-didyoumean
+    cryptography
     dask
     dask-jobqueue@git+https://github.com/dask/dask-jobqueue.git@0049ba7df81e3b687f0243f82b106df7a1e2ed32
     htcondor>=8.9.8a2


### PR DESCRIPTION
This PR resolve #4 by switching to TLS for all Dask communications. Dask-CHTC now also generates self-signed certificates for this purpose.