### PR TITLE
DOC: adapts documentation for first-time users

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,6 +1,6 @@
 name: pre-commit
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   pre-commit:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,6 @@
 name: tests
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   test:

--- a/dask_chtc/cli.py
+++ b/dask_chtc/cli.py
@@ -430,7 +430,8 @@ class JupyterJobManager:
     def start(self, jupyter_args: List[str]) -> "JupyterJobManager":
         if self.has_running_job():
             raise click.ClickException(
-                'You already have a running Jupyter notebook server; try the "status" subcommand to see it.'
+                "You already have a running Jupyter notebook server; "
+                'use "dask-chtc jupyter status" subcommand to see it\'s logs.'
             )
 
         self.prep_log_files()

--- a/docs/source/example.ipynb
+++ b/docs/source/example.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Example Notebook"
+    "# Dask Cluster Creation"
    ]
   },
   {

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -50,6 +50,11 @@ These pages will walk you through the various aspects of using Dask-CHTC:
 :doc:`installation`
     How to install Python and Dask-CHTC on a CHTC submit node.
 
+:doc:`example`
+    A brief example Jupyter notebook,
+    showing how to start up a :class:`CHTCCluster`
+    and use it to perform some calculations.
+
 :doc:`jupyter`
     How to use Dask-CHTC to run a Jupyter notebook server on a CHTC submit node.
 
@@ -58,11 +63,6 @@ These pages will walk you through the various aspects of using Dask-CHTC:
     how to forward ports over SSH,
     which will allow you to connect to
     Jupyter notebooks and Dask dashboards running on CHTC submit nodes.
-
-:doc:`example`
-    A brief example Jupyter notebook,
-    showing how to start up a :class:`CHTCCluster`
-    and use it to perform some calculations.
 
 :doc:`docker`
     Information on how to build Docker images for use with Dask-CHTC.

--- a/docs/source/jupyter.rst
+++ b/docs/source/jupyter.rst
@@ -6,16 +6,21 @@ This pages assumes the Jupyter is available. For more details on connecting to
 Jupyter, see :ref:`forward ports over SSH <networking>`. This page will only
 detail how to start Jupyter.
 
-Running Jupyter through Dask-CHTC
-=================================
-
-.. attention::
-
-
 .. warning::
 
     **Do not** run Jupyter notebook servers on CHTC submit nodes except through
     the process described on this page.
+
+    Launching Jupyter with this process allows the CHTC admins to effectively
+    monitor resource usage in the Jupyter process and debug/info messages to be
+    more easily displayed.  If you persist the Jupyter session through other
+    means like tmux, the CHTC admins may kill your entire tmux session if it
+    consumes too much CPU and memory.
+
+Running Jupyter through Dask-CHTC
+=================================
+
+.. attention::
 
 You may want to interact with your Dask cluster through a
 `Jupyter notebook <https://jupyter.org/>`_.

--- a/docs/source/jupyter.rst
+++ b/docs/source/jupyter.rst
@@ -2,17 +2,9 @@
 
 .. py:currentmodule:: dask_chtc
 
+
 Running Jupyter through Dask-CHTC
 =================================
-
-You may want to interact with your Dask cluster through a
-`Jupyter notebook <https://jupyter.org/>`_.
-Dask-CHTC provides a way to run a Jupyter notebook server on a CHTC submit node.
-
-.. warning::
-
-    **Do not** run Jupyter notebook servers on CHTC submit nodes except through
-    the process described on this page.
 
 .. attention::
 
@@ -21,6 +13,25 @@ Dask-CHTC provides a way to run a Jupyter notebook server on a CHTC submit node.
     to actually connect to the Jupyter notebook servers that you will learn
     how to run here. We recommend skimming this page, then reading about
     port forwarding, then coming back here to try out the commands in full.
+
+.. warning::
+
+    **Do not** run Jupyter notebook servers on CHTC submit nodes except through
+    the process described on this page.
+
+You may want to interact with your Dask cluster through a
+`Jupyter notebook <https://jupyter.org/>`_.
+Dask-CHTC provides a way to run a Jupyter notebook server on a CHTC submit node.
+
+
+.. _Jupyter install documentation: https://jupyter.org/install
+
+.. warning::
+
+   Jupyter must be installed. This amounts to following the
+   `Jupyter install documentation`_, which amounts to running
+   ``conda install -c conda-forge jupyterlab`` or adding `jupyter` to the
+   ``environment.yml`` file.
 
 You can run a notebook server via the Dask-CHTC command line tool, via the
 ``jupyter`` subcommand.

--- a/docs/source/jupyter.rst
+++ b/docs/source/jupyter.rst
@@ -86,8 +86,8 @@ command would be
             http://localhost:8888/?token=fedee94f539b0beea492bb358d549ed79025b714f3b308c4
          or http://127.0.0.1:8888/?token=fedee94f539b0beea492bb358d549ed79025b714f3b308c4
 
-HTCondor job events outputs some diagnostic information into this output
-stream. These messages may be helpful if your notebook server job is
+Dask-CHTC mixes HTCondor job diagnostic information into the normal Jupyter output stream.
+These messages may be helpful if your notebook server job is
 unexpectedly interrupted.
 
 Just like running ``jupyter lab``, if you press Control-C,

--- a/docs/source/jupyter.rst
+++ b/docs/source/jupyter.rst
@@ -2,17 +2,15 @@
 
 .. py:currentmodule:: dask_chtc
 
+This pages assumes the Jupyter is available. For more details on connecting to
+Jupyter, see :ref:`forward ports over SSH <networking>`. This page will only
+detail how to start Jupyter.
 
 Running Jupyter through Dask-CHTC
 =================================
 
 .. attention::
 
-    You will need to learn how to
-    :ref:`forward ports over SSH <networking>`
-    to actually connect to the Jupyter notebook servers that you will learn
-    how to run here. We recommend skimming this page, then reading about
-    port forwarding, then coming back here to try out the commands in full.
 
 .. warning::
 
@@ -23,15 +21,13 @@ You may want to interact with your Dask cluster through a
 `Jupyter notebook <https://jupyter.org/>`_.
 Dask-CHTC provides a way to run a Jupyter notebook server on a CHTC submit node.
 
-
 .. _Jupyter install documentation: https://jupyter.org/install
 
 .. warning::
 
-   Jupyter must be installed. This amounts to following the
-   `Jupyter install documentation`_, which amounts to running
-   ``conda install -c conda-forge jupyterlab`` or adding `jupyter` to the
-   ``environment.yml`` file.
+   Jupyter must be installed, which amounts to running ``conda install
+   jupyterlab`` or adding `jupyter` to your ``environment.yml`` file. For more
+   detail, see the `Jupyter install documentation`_,
 
 You can run a notebook server via the Dask-CHTC command line tool, via the
 ``jupyter`` subcommand.
@@ -67,9 +63,8 @@ It is designed to mimic the behavior of running a Jupyter notebook server on
 your local machine. Any command line arguments you pass to it will be
 passed to the actual ``jupyter`` command line tool.
 
-For example, if you normally start up a Jupyter Lab instance with ``jupyter
-lab``. The equivalent command for Dask-CHTC is ``dask-chtc jupyter run lab``
-command would be
+Jupyter Lab instances are normally started with ``jupyter
+lab``. The equivalent command for Dask-CHTC is ``dask-chtc jupyter run lab``:
 
 .. code-block:: console
 

--- a/docs/source/jupyter.rst
+++ b/docs/source/jupyter.rst
@@ -55,24 +55,10 @@ The ``run`` subcommand is the simplest way to launch a Jupyter notebook server.
 It is designed to mimic the behavior of running a Jupyter notebook server on
 your local machine. Any command line arguments you pass to it will be
 passed to the actual ``jupyter`` command line tool.
-For example, if you normally start up a Jupyter Lab instance by running
 
-.. code-block:: console
-
-    $ jupyter lab
-    [... Jupyter startup logs cut ...]
-    [I 10:31:41.908 LabApp] Use Control-C to stop this server and shut down all kernels (twice to skip confirmation).
-    [W 10:31:41.966 LabApp] No web browser found: could not locate runnable browser.
-    [C 10:31:41.967 LabApp]
-
-        To access the notebook, open this file in a browser:
-            file:///home/karpel/.local/share/jupyter/runtime/nbserver-2176065-open.html
-        Or copy and paste one of these URLs:
-            http://localhost:8888/?token=9af0f23248bc26014727d1dc85b5fcc07f4803caf777f87a
-         or http://127.0.0.1:8888/?token=9af0f23248bc26014727d1dc85b5fcc07f4803caf777f87a
-
-
-then the equivalent ``dask-chtc jupyter`` command would be
+For example, if you normally start up a Jupyter Lab instance with ``jupyter
+lab``. The equivalent command for Dask-CHTC is ``dask-chtc jupyter run lab``
+command would be
 
 .. code-block:: console
 
@@ -89,9 +75,8 @@ then the equivalent ``dask-chtc jupyter`` command would be
             http://localhost:8888/?token=fedee94f539b0beea492bb358d549ed79025b714f3b308c4
          or http://127.0.0.1:8888/?token=fedee94f539b0beea492bb358d549ed79025b714f3b308c4
 
-Note the HTCondor job events are mixed into the output stream.
-This is purely for diagnostic purposes;
-you may (for example) find them helpful if your notebook server job is
+HTCondor job events outputs some diagnostic information into this output
+stream. These messages may be helpful if your notebook server job is
 unexpectedly interrupted.
 
 Just like running ``jupyter lab``, if you press Control-C,


### PR DESCRIPTION
**What does this PR implement?**
This is my first time running Dask-CHTC. I've adapted the documentation for items I'd like to see in the documentation. So far, these are:

* Adds note about installing Jupyter before running
* Only show `dask-chtc jupyter run lab` instead of that and the unuseful `jupyter lab`.
* Renames "Example Notebook" to "Dask Cluster Creation."

**Reference issues/PRs**
Other issues that came up in this first usage are #25, #26 and #27.
